### PR TITLE
Instadapp: add Liquity resolver (read-only positional data)

### DIFF
--- a/contracts/flusher/balances.sol
+++ b/contracts/flusher/balances.sol
@@ -28,7 +28,7 @@ contract Resolver {
             tokensBal[i] = Balances({
                 flusher: flushers[i],
                 balance: bals,
-                isDeployed: isContractDeployed(flushers[i]);
+                isDeployed: isContractDeployed(flushers[i])
             });
         }
         return tokensBal;

--- a/contracts/protocols/mainnet/liquity.sol
+++ b/contracts/protocols/mainnet/liquity.sol
@@ -1,0 +1,101 @@
+pragma solidity ^0.6.0;
+pragma experimental ABIEncoderV2;
+
+interface TroveManagerLike {
+  function getCurrentICR(address _borrower, uint _price) external view returns (uint);
+  function getEntireDebtAndColl(address _borrower) external view returns (
+    uint debt, 
+    uint coll, 
+    uint pendingLUSDDebtReward, 
+    uint pendingETHReward
+  );
+}
+
+interface StabilityPoolLike {
+  function getCompoundedLUSDDeposit(address _depositor) external view returns (uint);
+  function getDepositorETHGain(address _depositor) external view returns (uint);
+  function getDepositorLQTYGain(address _depositor) external view returns (uint);
+}
+
+abstract contract StakingLike {
+  mapping(address => uint) public stakes;
+  function getPendingETHGain(address _user) external virtual view returns (uint);
+  function getPendingLUSDGain(address _user) external virtual view returns (uint);
+}
+
+abstract contract PriceFeedLike {
+  uint public lastGoodPrice;
+}
+
+contract Helpers {
+  TroveManagerLike internal constant troveManager =
+    TroveManagerLike(0xA39739EF8b0231DbFA0DcdA07d7e29faAbCf4bb2);
+
+  StabilityPoolLike internal constant stabilityPool = 
+    StabilityPoolLike(0x66017D22b0f8556afDd19FC67041899Eb65a21bb);
+
+  StakingLike internal constant staking =
+    StakingLike(0x4f9Fbb3f1E99B56e0Fe2892e623Ed36A76Fc605d);
+
+  PriceFeedLike internal constant priceFeed = 
+    PriceFeedLike(0x4c517D4e2C851CA76d7eC94B805269Df0f2201De);
+  
+  struct Trove {
+    uint collateral;
+    uint debt;
+    uint icr;
+  }
+
+  struct StabilityDeposit {
+    uint deposit;
+    uint ethGain;
+    uint lqtyGain;
+  }
+
+  struct Stake {
+    uint amount;
+    uint ethGain;
+    uint lusdGain;
+  }
+
+  struct Position {
+    Trove trove;
+    StabilityDeposit stability;
+    Stake stake;
+  }
+}
+
+
+contract Resolver is Helpers {
+  function getTrove(address owner) public view returns (Trove memory) {
+    (uint debt, uint collateral, uint _, uint __) = troveManager.getEntireDebtAndColl(owner);
+    uint price = priceFeed.lastGoodPrice();
+    uint icr = troveManager.getCurrentICR(owner, price);
+    return Trove(collateral, debt, icr);
+  }
+
+  function getStabilityDeposit(address owner) public view returns (StabilityDeposit memory) {
+    uint deposit = stabilityPool.getCompoundedLUSDDeposit(owner);
+    uint ethGain = stabilityPool.getDepositorETHGain(owner);
+    uint lqtyGain = stabilityPool.getDepositorLQTYGain(owner);
+    return StabilityDeposit(deposit, ethGain, lqtyGain);
+  }
+
+  function getStake(address owner) public view returns (Stake memory) {
+    uint amount = staking.stakes(owner);
+    uint ethGain = staking.getPendingETHGain(owner);
+    uint lusdGain = staking.getPendingLUSDGain(owner);
+    return Stake(amount, ethGain, lusdGain);
+  }
+
+  function getPosition(address owner) external view returns (Position memory) {
+    Trove memory trove = getTrove(owner);
+    StabilityDeposit memory stability = getStabilityDeposit(owner);
+    Stake memory stake = getStake(owner);
+    return Position(trove, stability, stake);
+  }
+}
+
+contract InstaLiquityResolver is Resolver {
+  string public constant name = "Liquity-Resolver-v1";
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "The smart contracts which simplifies read operations.",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "hardhat test"
   },
   "repository": {
     "type": "git",

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -1,0 +1,95 @@
+const { expect } = require("chai");
+const hardhatConfig = require("../hardhat.config");
+const { BigNumber } = hre.ethers;
+
+// Deterministic block number to run these tests from on forked mainnet. If you change this, tests will break.
+const BLOCK_NUMBER = 12478959;
+
+// Liquity user with a Trove, Stability deposit, and Stake
+const JUSTIN_SUN_ADDRESS = "0x903d12bf2c57a29f32365917c706ce0e1a84cce3";
+
+/* Begin: Mock test data (based on specified BLOCK_NUMBER and JUSTIN_SUN_ADDRESS) */
+const expectedTrovePosition = [
+  /* collateral */ BigNumber.from("582880000000000000000000"),
+  /* debt */ BigNumber.from("372000200000000000000000000"),
+  /* icr */ BigNumber.from("3839454035181671407"),
+];
+const expectedStabilityPosition = [
+  /* deposit */ BigNumber.from("299979329615565997640451998"),
+  /* ethGain */ BigNumber.from("8629038660000000000"),
+  /* lqtyGain */ BigNumber.from("53244322633874479119945"),
+];
+const expectedStakePosition = [
+  /* amount */ BigNumber.from("981562996504090969804965"),
+  /* ethGain */ BigNumber.from("18910541408996344243"),
+  /* lusdGain */ BigNumber.from("66201062534511228032281"),
+];
+/* End: Mock test data */
+
+describe("InstaLiquityResolver", () => {
+  let liquity;
+
+  before(async () => {
+    await resetHardhatBlockNumber(BLOCK_NUMBER); // Start tests from clean mainnet fork at BLOCK_NUMBER
+
+    const LiquityFactory = await hre.ethers.getContractFactory(
+      "InstaLiquityResolver"
+    );
+
+    liquity = await LiquityFactory.deploy();
+    await liquity.deployed();
+  });
+
+  it("deploys the resolver", () => {
+    expect(liquity.address).to.exist;
+  });
+
+  describe("getTrove()", () => {
+    it("returns a user's Trove position", async () => {
+      const trovePosition = await liquity.getTrove(JUSTIN_SUN_ADDRESS);
+      expect(trovePosition).to.eql(expectedTrovePosition);
+    });
+  });
+
+  describe("getStabilityDeposit()", () => {
+    it("returns a user's Stability Pool position", async () => {
+      const stabilityPosition = await liquity.getStabilityDeposit(
+        JUSTIN_SUN_ADDRESS
+      );
+      expect(stabilityPosition).to.eql(expectedStabilityPosition);
+    });
+  });
+
+  describe("getStake()", () => {
+    it("returns a user's Stake position", async () => {
+      const stakePosition = await liquity.getStake(JUSTIN_SUN_ADDRESS);
+      expect(stakePosition).to.eql(expectedStakePosition);
+    });
+  });
+
+  describe("getPosition()", () => {
+    it("returns a user's Liquity position", async () => {
+      const position = await liquity.getPosition(JUSTIN_SUN_ADDRESS);
+      const expectedPosition = [
+        expectedTrovePosition,
+        expectedStabilityPosition,
+        expectedStakePosition,
+      ];
+      expect(position).to.eql(expectedPosition);
+    });
+  });
+});
+
+const resetHardhatBlockNumber = async (blockNumber) => {
+  return await hre.network.provider.request({
+    method: "hardhat_reset",
+    params: [
+      {
+        forking: {
+          jsonRpcUrl: hardhatConfig.networks.hardhat.forking.url,
+          blockNumber,
+        },
+      },
+    ],
+  });
+};

--- a/test/liquity.js
+++ b/test/liquity.js
@@ -24,6 +24,13 @@ const expectedStakePosition = [
   /* ethGain */ BigNumber.from("18910541408996344243"),
   /* lusdGain */ BigNumber.from("66201062534511228032281"),
 ];
+
+const expectedSystemState = [
+  /* borrowFee */ BigNumber.from("6900285109012952"),
+  /* ethTvl */ BigNumber.from("852500462432421494350957"),
+  /* tcr */ BigNumber.from("3232993993257432140"),
+  /* isInRecoveryMode */ false,
+];
 /* End: Mock test data */
 
 describe("InstaLiquityResolver", () => {
@@ -76,6 +83,13 @@ describe("InstaLiquityResolver", () => {
         expectedStakePosition,
       ];
       expect(position).to.eql(expectedPosition);
+    });
+  });
+
+  describe("getSystemState()", () => {
+    it("returns Liquity system state", async () => {
+      const systemState = await liquity.getSystemState();
+      expect(systemState).to.eql(expectedSystemState);
     });
   });
 });


### PR DESCRIPTION
As per Instadapp integration guide: https://www.notion.so/Instadapp-Integration-98d638a7917344afb4e2be63a09cf9a6

We're required to add a read-only wrapper over the protocol.

I've added five public readers:
- Trove position data (collateral, debt, ICR)
- Stability deposit position data (deposit, ethGain, lqtyGain)
- Stake position data (amount, ethGain, lusdGain)
- Overall position data (Trove, StabilityDeposit, Stake)
- Overall system state (borrowFee, ethTvl, TCR, isInRecoveryMode)

To run the tests (`npm test`) you need to add an `ALCHEMY_API_KEY` to your environment variables, and comment out the Uniswap test file since it's broken and kills the test suite otherwise.

